### PR TITLE
Fix Responses API image handling

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -796,7 +796,7 @@ async def get_response(
                     img if str(img).startswith("data:") else f"data:image/jpeg;base64,{img}"
                 )
                 contents.append(
-                    {"type": "input_image", "image_url": {"url": img_url}}
+                    {"type": "input_image", "image_url": img_url}
                 )
             input_data = (
                 [{"role": "user", "content": contents}]

--- a/tests/test_input_image_url.py
+++ b/tests/test_input_image_url.py
@@ -1,0 +1,21 @@
+import pytest
+import openai
+from gabriel.utils import openai_utils
+
+class DummyClient:
+    def __init__(self):
+        self.responses = self
+    async def create(self, **kwargs):
+        DummyClient.captured = kwargs
+        class Resp:
+            output_text = "ok"
+        return Resp()
+
+@pytest.mark.asyncio
+async def test_get_response_encodes_image(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    openai_utils.client_async = None
+    dummy = DummyClient()
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: dummy)
+    await openai_utils.get_response("Describe", images=["abc"], use_dummy=False)
+    assert DummyClient.captured["input"][0]["content"][1]["image_url"] == "data:image/jpeg;base64,abc"


### PR DESCRIPTION
## Summary
- Ensure `get_response` sends image URLs as strings for the Responses API
- Add regression test confirming base64 images are encoded correctly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689bd753aa74832ebcb9d8ebf1dd8439