### PR TITLE
Allow passing kwargs to get_all_responses

### DIFF
--- a/regional.py
+++ b/regional.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Any
 
 import pandas as pd
 
@@ -63,24 +63,24 @@ class Regional:
                 ids.append(f"{region}|{topic}")
         return prompts, ids
 
-    async def run(self, *, reset_files: bool = False, **kwargs) -> pd.DataFrame:
+    async def run(self, *, reset_files: bool = False, **kwargs: Any) -> pd.DataFrame:
         prompts, ids = self._build()
         csv_path = os.path.join(self.save_path, "regional_responses.csv")
+        kwargs.setdefault("use_web_search", True)
+        kwargs.setdefault("search_context_size", self.search_context_size)
+        kwargs.setdefault("max_tokens", 50000)
+        kwargs.setdefault("timeout", 450)
+        kwargs.setdefault("model", self.model)
+        kwargs.setdefault("n_parallels", self.n_parallels)
+        kwargs.setdefault("use_dummy", self.use_dummy)
         resp_df = await get_all_responses(
             prompts=prompts,
             identifiers=ids,
-            n_parallels=self.n_parallels,
-            model=self.model,
-            use_web_search=True,
-            search_context_size=self.search_context_size,
             reasoning_effort=self.reasoning_effort,
             reasoning_summary=self.reasoning_summary,
             save_path=csv_path,
             reset_files=reset_files,
-            use_dummy=self.use_dummy,
             print_example_prompt=self.print_example_prompt,
-            max_tokens=50000,
-            timeout=450,
             **kwargs,
         )
 

--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -183,6 +183,11 @@ class Classify:
         csv_path = os.path.join(self.cfg.save_dir, f"{base_name}_raw_responses.csv")
 
         kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("json_mode", self.cfg.modality != "audio")
+        kwargs.setdefault("timeout", self.cfg.timeout)
+        kwargs.setdefault("model", self.cfg.model)
+        kwargs.setdefault("n_parallels", self.cfg.n_parallels)
+        kwargs.setdefault("use_dummy", self.cfg.use_dummy)
 
         if not isinstance(self.cfg.n_runs, int) or self.cfg.n_runs < 1:
             raise ValueError("n_runs must be an integer >= 1")
@@ -193,13 +198,8 @@ class Classify:
                 identifiers=ids,
                 prompt_images=prompt_images,
                 prompt_audio=prompt_audio,
-                n_parallels=self.cfg.n_parallels,
                 save_path=csv_path,
                 reset_files=reset_files,
-                json_mode=self.cfg.modality != "audio",
-                model=self.cfg.model,
-                use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=True,
@@ -233,13 +233,8 @@ class Classify:
                 identifiers=ids_all,
                 prompt_images=prompt_images_all,
                 prompt_audio=prompt_audio_all,
-                n_parallels=self.cfg.n_parallels,
                 save_path=csv_path,
                 reset_files=reset_files,
-                json_mode=self.cfg.modality != "audio",
-                model=self.cfg.model,
-                use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=True,

--- a/src/gabriel/tasks/codify.py
+++ b/src/gabriel/tasks/codify.py
@@ -528,6 +528,7 @@ class Codify:
         use_dummy: bool = False,
         reasoning_effort: Optional[str] = None,
         reasoning_summary: Optional[str] = None,
+        **kwargs: Any,
     ) -> pd.DataFrame:
         """
         Process all texts in the dataframe, coding passages according to categories.
@@ -621,21 +622,23 @@ class Codify:
         
         # Process all chunks - let the model handle JSON structure naturally
         expected_schema = None
-        
+
+        kwargs.setdefault("json_mode", True)
+        kwargs.setdefault("timeout", 300)
+        kwargs.setdefault("print_example_prompt", True)
+        kwargs.setdefault("n_parallels", n_parallels)
+        kwargs.setdefault("model", model)
+        kwargs.setdefault("use_dummy", use_dummy)
+
         batch_df = await get_all_responses(
             prompts=prompts,
             identifiers=identifiers,
-            n_parallels=n_parallels,
             save_path=os.path.join(save_dir, file_name),
             reset_files=reset_files,
-            use_dummy=use_dummy,
-            json_mode=True,
             expected_schema=expected_schema,
-            model=model,
-            timeout=300,  # This will be forwarded to get_response via **kwargs
-            print_example_prompt=True,
             reasoning_effort=reasoning_effort,
             reasoning_summary=reasoning_summary,
+            **kwargs,
         )
         
         # Group results by original text index and batch

--- a/src/gabriel/tasks/county_counter.py
+++ b/src/gabriel/tasks/county_counter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from datetime import datetime
-from typing import List, Optional, Dict
+from typing import List, Optional, Dict, Any
 
 import pandas as pd
 
@@ -78,8 +78,8 @@ class CountyCounter:
         )
         self.regional = Regional(self.df, self.county_col, self.topics, reg_cfg)
 
-    async def run(self, *, reset_files: bool = False) -> pd.DataFrame:
-        reports_df = await self.regional.run(reset_files=reset_files)
+    async def run(self, *, reset_files: bool = False, **kwargs: Any) -> pd.DataFrame:
+        reports_df = await self.regional.run(reset_files=reset_files, **kwargs)
         results = reports_df[["region"]].copy()
 
         for topic in self.topics:
@@ -107,7 +107,11 @@ class CountyCounter:
                 )
             rater = EloRater(cfg)
             elo_df = await rater.run(
-                df_topic, text_col="text", id_col="identifier", reset_files=reset_files
+                df_topic,
+                text_col="text",
+                id_col="identifier",
+                reset_files=reset_files,
+                **kwargs,
             )
             elo_df["identifier"] = elo_df["identifier"].astype(str)
             results["region"] = results["region"].astype(str)

--- a/src/gabriel/tasks/elo.py
+++ b/src/gabriel/tasks/elo.py
@@ -334,6 +334,12 @@ class EloRater:
         history_pairs: Dict[str, List[Tuple[str, str]]] = {a: [] for a in attr_keys}
         se_store: Dict[str, Dict[str, float]] = {a: {i: np.nan for i in item_ids} for a in attr_keys}
 
+        kwargs.setdefault("json_mode", self.cfg.modality != "audio")
+        kwargs.setdefault("timeout", self.cfg.timeout)
+        kwargs.setdefault("model", self.cfg.model)
+        kwargs.setdefault("n_parallels", self.cfg.n_parallels)
+        kwargs.setdefault("use_dummy", self.cfg.use_dummy)
+
         def expected(r_a: float, r_b: float) -> float:
             return 1 / (1 + 10 ** ((r_b - r_a) / 400))
 
@@ -398,13 +404,8 @@ class EloRater:
                 identifiers=ids,
                 prompt_images=pair_images or None,
                 prompt_audio=pair_audio or None,
-                n_parallels=self.cfg.n_parallels,
-                model=self.cfg.model,
-                json_mode=self.cfg.modality != "audio",
                 save_path=os.path.join(self.save_path, f"round{rnd}.csv"),
                 reset_files=reset_files,
-                use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 print_example_prompt=self.cfg.print_example_prompt,

--- a/src/gabriel/tasks/paraphrase.py
+++ b/src/gabriel/tasks/paraphrase.py
@@ -62,15 +62,15 @@ class Paraphrase:
                 identifiers.append(f"row_{idx}_rev{j}")
 
         save_path = os.path.join(self.cfg.save_dir, self.cfg.file_name)
+        kwargs.setdefault("model", self.cfg.model)
+        kwargs.setdefault("json_mode", self.cfg.json_mode)
+        kwargs.setdefault("use_web_search", self.cfg.use_web_search)
+        kwargs.setdefault("n_parallels", self.cfg.n_parallels)
+        kwargs.setdefault("use_dummy", self.cfg.use_dummy)
         resp_df = await get_all_responses(
             prompts=prompts,
             identifiers=identifiers,
             save_path=save_path,
-            model=self.cfg.model,
-            json_mode=self.cfg.json_mode,
-            use_web_search=self.cfg.use_web_search,
-            n_parallels=self.cfg.n_parallels,
-            use_dummy=self.cfg.use_dummy,
             reset_files=reset_files,
             reasoning_effort=self.cfg.reasoning_effort,
             reasoning_summary=self.cfg.reasoning_summary,

--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -644,6 +644,11 @@ class Rank:
         final_path = os.path.join(self.cfg.save_dir, f"{base_name}_final.csv")
 
         kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("json_mode", self.cfg.modality != "audio")
+        kwargs.setdefault("timeout", self._TIMEOUT)
+        kwargs.setdefault("model", self.cfg.model)
+        kwargs.setdefault("n_parallels", self.cfg.n_parallels)
+        kwargs.setdefault("use_dummy", self.cfg.use_dummy)
         # Determine how many rounds have already been processed when
         # `reset_files` is False.  We look for files named
         # ``<base_name>_round<k>.csv`` to infer progress.  If a final
@@ -971,13 +976,8 @@ class Rank:
                 identifiers=ids,
                 prompt_images=pair_images or None,
                 prompt_audio=pair_audio or None,
-                n_parallels=self.cfg.n_parallels,
-                model=self.cfg.model,
-                json_mode=self.cfg.modality != "audio",
                 save_path=round_path,
                 reset_files=reset_files,
-                use_dummy=self.cfg.use_dummy,
-                timeout=self._TIMEOUT,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
                 **kwargs,

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -151,6 +151,11 @@ class Rate:
         csv_path = os.path.join(self.cfg.save_dir, f"{base_name}_raw_responses.csv")
 
         kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("json_mode", self.cfg.modality != "audio")
+        kwargs.setdefault("timeout", self.cfg.timeout)
+        kwargs.setdefault("model", self.cfg.model)
+        kwargs.setdefault("n_parallels", self.cfg.n_parallels)
+        kwargs.setdefault("use_dummy", self.cfg.use_dummy)
 
         if not isinstance(self.cfg.n_runs, int) or self.cfg.n_runs < 1:
             raise ValueError("n_runs must be an integer >= 1")
@@ -161,12 +166,7 @@ class Rate:
                 identifiers=ids,
                 prompt_images=prompt_images,
                 prompt_audio=prompt_audio,
-                n_parallels=self.cfg.n_parallels,
-                model=self.cfg.model,
                 save_path=csv_path,
-                use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
-                json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,
@@ -198,12 +198,7 @@ class Rate:
                 identifiers=ids_all,
                 prompt_images=prompt_images_all,
                 prompt_audio=prompt_audio_all,
-                n_parallels=self.cfg.n_parallels,
-                model=self.cfg.model,
                 save_path=csv_path,
-                use_dummy=self.cfg.use_dummy,
-                timeout=self.cfg.timeout,
-                json_mode=self.cfg.modality != "audio",
                 reset_files=reset_files,
                 reasoning_effort=self.cfg.reasoning_effort,
                 reasoning_summary=self.cfg.reasoning_summary,

--- a/src/gabriel/tasks/recursive_elo.py
+++ b/src/gabriel/tasks/recursive_elo.py
@@ -189,7 +189,13 @@ class RecursiveEloRater:
     # ------------------------------ Public ------------------------------
 
     async def run(
-        self, df: pd.DataFrame, text_col: str, id_col: str, *, reset_files: bool = False
+        self,
+        df: pd.DataFrame,
+        text_col: str,
+        id_col: str,
+        *,
+        reset_files: bool = False,
+        **kwargs: Any,
     ) -> pd.DataFrame:
         """
         Execute recursive Elo rating.
@@ -260,6 +266,7 @@ class RecursiveEloRater:
                 text_col="text",
                 id_col="identifier",
                 reset_files=reset_files,
+                **kwargs,
             )
 
             # Record stage columns if desired

--- a/src/gabriel/tasks/regional.py
+++ b/src/gabriel/tasks/regional.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Any
 
 import pandas as pd
 
@@ -65,24 +65,24 @@ class Regional:
                 ids.append(f"{region}|{topic}")
         return prompts, ids
 
-    async def run(self, *, reset_files: bool = False, **kwargs) -> pd.DataFrame:
+    async def run(self, *, reset_files: bool = False, **kwargs: Any) -> pd.DataFrame:
         prompts, ids = self._build()
         csv_path = os.path.join(self.save_path, "regional_responses.csv")
+        kwargs.setdefault("use_web_search", True)
+        kwargs.setdefault("search_context_size", self.cfg.search_context_size)
+        kwargs.setdefault("max_tokens", 50000)
+        kwargs.setdefault("timeout", 450)
+        kwargs.setdefault("model", self.cfg.model)
+        kwargs.setdefault("n_parallels", self.cfg.n_parallels)
+        kwargs.setdefault("use_dummy", self.cfg.use_dummy)
         resp_df = await get_all_responses(
             prompts=prompts,
             identifiers=ids,
-            n_parallels=self.cfg.n_parallels,
-            model=self.cfg.model,
-            use_web_search=True,
-            search_context_size=self.cfg.search_context_size,
             reasoning_effort=self.cfg.reasoning_effort,
             reasoning_summary=self.cfg.reasoning_summary,
             save_path=csv_path,
             reset_files=reset_files,
-            use_dummy=self.cfg.use_dummy,
             print_example_prompt=self.cfg.print_example_prompt,
-            max_tokens=50000,
-            timeout=450,
             **kwargs,
         )
 

--- a/src/gabriel/utils/parsing.py
+++ b/src/gabriel/utils/parsing.py
@@ -142,6 +142,7 @@ async def clean_json_df(
     save_path: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    **kwargs: Any,
 ) -> pd.DataFrame:
     """Ensure specified DataFrame columns contain valid JSON.
 
@@ -227,17 +228,18 @@ async def clean_json_df(
         else:
             tmp_path = save_path
         try:
+            kwargs.setdefault("json_mode", True)
+            kwargs.setdefault("print_example_prompt", False)
             resp_df = await get_all_responses(
                 prompts=prompts,
                 identifiers=identifiers,
                 model=model,
-                json_mode=True,
                 use_dummy=use_dummy,
                 reasoning_effort=reasoning_effort,
                 reasoning_summary=reasoning_summary,
-                print_example_prompt=False,
                 save_path=tmp_path,
                 reset_files=True,
+                **kwargs,
             )
         finally:
             if cleanup:


### PR DESCRIPTION
## Summary
- Allow task and utility methods to forward arbitrary keyword arguments to `get_all_responses`
- Set sensible defaults with `kwargs.setdefault` so options like `timeout` can be overridden
- Ensure regional analysis helpers accept kwarg overrides and propagate them

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pandas' and 'openai')*


------
https://chatgpt.com/codex/tasks/task_b_689e29d6c1d4832ea1d4534c2751ec46