### PR TITLE
Log example prompt by default

### DIFF
--- a/openai_utils_aug_12_save.py
+++ b/openai_utils_aug_12_save.py
@@ -973,7 +973,7 @@ async def get_all_responses(
             rate_headers=rate_headers,
         )
         example_prompt, _ = todo_pairs[0]
-        logger.info(f"Example prompt: {example_prompt}")
+        logger.warning(f"Example prompt: {example_prompt}")
     # Dynamically adjust the maximum number of parallel workers based on rate
     # limits.  We base the concurrency on your API’s per‑minute request and
     # token budgets and the average prompt length.  This calculation only

--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1102,7 +1102,7 @@ async def get_all_responses(
             rate_headers=rate_headers,
         )
         example_prompt, _ = todo_pairs[0]
-        logger.info(f"Example prompt: {example_prompt}")
+        logger.warning(f"Example prompt: {example_prompt}")
     # Dynamically adjust the maximum number of parallel workers based on rate
     # limits.  We base the concurrency on your API’s per‑minute request and
     # token budgets and the average prompt length.  This calculation only


### PR DESCRIPTION
## Summary
- Emit example prompt at warning level so it's visible with default logging.

## Testing
- `pytest` *(fails: TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str')*


------
https://chatgpt.com/codex/tasks/task_b_68a376482fec832eab43bf403ae0709a