### PR TITLE
Add async embedding utilities

### DIFF
--- a/src/gabriel/utils/__init__.py
+++ b/src/gabriel/utils/__init__.py
@@ -1,6 +1,11 @@
 """Utility helpers for GABRIEL."""
 
-from .openai_utils import get_response, get_all_responses
+from .openai_utils import (
+    get_response,
+    get_all_responses,
+    get_embedding,
+    get_all_embeddings,
+)
 from .image_utils import encode_image
 from .audio_utils import encode_audio
 from .media_utils import load_image_inputs, load_audio_inputs
@@ -20,6 +25,8 @@ from .word_matching import (
 __all__ = [
     "get_response",
     "get_all_responses",
+    "get_embedding",
+    "get_all_embeddings",
     "get_logger",
     "set_log_level",
     "Teleprompter",

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -58,6 +58,11 @@ def test_get_response_audio_dummy():
     assert responses and responses[0].startswith("DUMMY")
 
 
+def test_get_embedding_dummy():
+    emb, _ = asyncio.run(openai_utils.get_embedding("hi", use_dummy=True))
+    assert isinstance(emb, list) and emb and isinstance(emb[0], float)
+
+
 def test_safest_json_codeblock_list():
     raw = ["```json\n{\n \"speech\": true,\n \"music\": false\n}\n```"]
     parsed = asyncio.run(safest_json(raw))
@@ -121,6 +126,18 @@ def test_get_all_responses_audio_dummy(tmp_path):
         )
     )
     assert len(df) == 1
+
+
+def test_get_all_embeddings_dummy(tmp_path):
+    res = asyncio.run(
+        openai_utils.get_all_embeddings(
+            texts=["a", "b"],
+            identifiers=["1", "2"],
+            save_path=str(tmp_path / "emb.pkl"),
+            use_dummy=True,
+        )
+    )
+    assert set(res.keys()) == {"1", "2"}
 
 
 def test_ratings_dummy(tmp_path):


### PR DESCRIPTION
## Summary
- support single and batched embedding requests via new `get_embedding` and `get_all_embeddings`
- export embedding helpers from utility package
- test embedding helpers with dummy backend

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a4b5cbcff4832eba4d471cecb65d12