### PR TITLE
Fix reset flag for embedding calls in merge and deduplicate

### DIFF
--- a/src/gabriel/tasks/deduplicate.py
+++ b/src/gabriel/tasks/deduplicate.py
@@ -83,7 +83,7 @@ class Deduplicate:
                 texts=uniques,
                 identifiers=uniques,
                 save_path=os.path.join(self.cfg.save_dir, "deduplicate_embeddings.pkl"),
-                reset_files=reset_files,
+                reset_file=reset_files,
                 use_dummy=self.cfg.use_dummy,
                 verbose=False,
             )

--- a/src/gabriel/tasks/merge.py
+++ b/src/gabriel/tasks/merge.py
@@ -110,7 +110,7 @@ class Merge:
                 texts=short_uniques,
                 identifiers=short_uniques,
                 save_path=os.path.join(self.cfg.save_dir, "short_embeddings.pkl"),
-                reset_files=reset_files,
+                reset_file=reset_files,
                 use_dummy=self.cfg.use_dummy,
                 verbose=False,
             )
@@ -118,7 +118,7 @@ class Merge:
                 texts=long_uniques,
                 identifiers=long_uniques,
                 save_path=os.path.join(self.cfg.save_dir, "long_embeddings.pkl"),
-                reset_files=reset_files,
+                reset_file=reset_files,
                 use_dummy=self.cfg.use_dummy,
                 verbose=False,
             )


### PR DESCRIPTION
## Summary
- avoid passing unsupported `reset_files` argument into embedding calls in `Merge` and `Deduplicate`
- ensure embedding cache resets use `reset_file` parameter only

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a6526e544c832e9b02a1e13c322138