### PR TITLE
Ensure bucket prompts include selected buckets and add summary stats

### DIFF
--- a/src/gabriel/prompts/bucket_prompt.jinja2
+++ b/src/gabriel/prompts/bucket_prompt.jinja2
@@ -50,7 +50,7 @@ BEGIN BUCKET CANDIDATES
 END BUCKET CANDIDATES
 
 From these candidates only, choose the buckets (verbatim as they appear in the candidate keys) that best group the raw terms with the desired specificity, substance, and mutual exclusivity.
-    {% if selected_buckets and selected_buckets|length > 0 %}
+{% if selected_buckets %}
 The following bucket terms have **already been selected**; you should **not** select any similar/overlapping buckets from the candidate list:
 
 BEGIN ALREADY FINALIZED BUCKETS

--- a/src/gabriel/tasks/bucket.py
+++ b/src/gabriel/tasks/bucket.py
@@ -151,7 +151,6 @@ class Bucket:
         def _vote_prompts(opts: List[str], selected: List[str], tag: str):
             pr: List[str] = []
             idn: List[str] = []
-            sel_map = {b: candidate_defs.get(b, "") for b in selected}
             for rep in range(self.cfg.repeat_voting):
                 random.shuffle(opts)
                 chunks = [
@@ -167,6 +166,9 @@ class Bucket:
                         if self.cfg.raw_term_definitions
                         else sample_list
                     )
+                    selected_map = {
+                        b: candidate_defs.get(b, "") for b in selected
+                    }
                     pr.append(
                         self.template.render(
                             terms=sample_terms,
@@ -176,7 +178,7 @@ class Bucket:
                             or "",
                             voting=True,
                             bucket_candidates=ch,
-                            selected_buckets=sel_map,
+                            selected_buckets=selected_map if selected_map else None,
                         )
                     )
                     idn.append(f"vote|{tag}|{rep}|{ci}")

--- a/src/gabriel/tasks/discover.py
+++ b/src/gabriel/tasks/discover.py
@@ -271,14 +271,22 @@ class Discover:
                 circ_true = classify_result[circ_col].fillna(False).sum()
                 sq_true = classify_result[sq_col].fillna(False).sum()
                 total = classify_result[[circ_col, sq_col]].notna().any(axis=1).sum()
-                diff = ((circ_true - sq_true) / total * 100) if total else None
+                circ_pct = (circ_true / total * 100) if total else None
+                sq_pct = (sq_true / total * 100) if total else None
+                net_pct = (
+                    (circ_pct - sq_pct)
+                    if circ_pct is not None and sq_pct is not None
+                    else None
+                )
                 summary_records.append({
                     "label": lab,
                     "circle_true": circ_true,
                     "square_true": sq_true,
                     "total": total,
-                "difference_pct": diff,
-            })
+                    "circle_pct": circ_pct,
+                    "square_pct": sq_pct,
+                    "net_pct": net_pct,
+                })
             summary_df = pd.DataFrame(summary_records)
         else:
             clf_cfg = ClassifyConfig(


### PR DESCRIPTION
## Summary
- Rebuild voting prompts so previously selected buckets are always passed through to the template
- Record per-bucket frequency percentages (circle, square, and net) in the Discover summary
- Simplify bucket prompt template to show selected buckets when present

## Testing
- `pytest` *(fails: AttributeError: custom_prompt, FileNotFoundError, async functions not supported)*

------
https://chatgpt.com/codex/tasks/task_i_68a9231b5bb8832e8a50123f3a937224