### PR TITLE
Enhance deidentify warm-start and reuse capabilities

### DIFF
--- a/src/gabriel/api.py
+++ b/src/gabriel/api.py
@@ -178,6 +178,7 @@ async def deidentify(
     *,
     save_dir: str,
     grouping_column: Optional[str] = None,
+    mapping_column: Optional[str] = None,
     model: str = "gpt-5-mini",
     n_parallels: int = 750,
     use_dummy: bool = False,
@@ -187,6 +188,8 @@ async def deidentify(
     additional_guidelines: str = "",
     reasoning_effort: Optional[str] = None,
     reasoning_summary: Optional[str] = None,
+    n_passes: int = 1,
+    use_existing_mappings_only: bool = False,
     template_path: Optional[str] = None,
     reset_files: bool = False,
     **cfg_kwargs,
@@ -205,12 +208,15 @@ async def deidentify(
         additional_guidelines=additional_guidelines,
         reasoning_effort=reasoning_effort,
         reasoning_summary=reasoning_summary,
+        n_passes=n_passes,
+        use_existing_mappings_only=use_existing_mappings_only,
         **cfg_kwargs,
     )
-    return await Deidentifier(cfg).run(
+    return await Deidentifier(cfg, template_path=template_path).run(
         df,
         column_name,
         grouping_column=grouping_column,
+        mapping_column=mapping_column,
         reset_files=reset_files,
     )
 

--- a/src/gabriel/tasks/deidentify.py
+++ b/src/gabriel/tasks/deidentify.py
@@ -1,18 +1,24 @@
 from __future__ import annotations
 
+import ast
 import json
 import os
 import re
+from copy import deepcopy
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
 from ..core.prompt_template import PromptTemplate
-from ..utils.openai_utils import get_all_responses
 from ..utils import safest_json
+from ..utils.openai_utils import get_all_responses
 
 
+# ────────────────────────────
+# Configuration dataclass
+# ────────────────────────────
 @dataclass
 class DeidentifyConfig:
     """Configuration for :class:`Deidentifier`."""
@@ -28,8 +34,17 @@ class DeidentifyConfig:
     additional_guidelines: str = ""
     reasoning_effort: Optional[str] = None
     reasoning_summary: Optional[str] = None
+    n_passes: int = 1
+    use_existing_mappings_only: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.n_passes, int) or self.n_passes < 1:
+            raise ValueError("n_passes must be an integer >= 1")
 
 
+# ────────────────────────────
+# Main de-identification task
+# ────────────────────────────
 class Deidentifier:
     """Iterative de-identification of sensitive entities in text."""
 
@@ -39,6 +54,9 @@ class Deidentifier:
         template: Optional[PromptTemplate] = None,
         template_path: Optional[str] = None,
     ) -> None:
+        expanded = Path(os.path.expandvars(os.path.expanduser(cfg.save_dir)))
+        expanded.mkdir(parents=True, exist_ok=True)
+        cfg.save_dir = str(expanded)
         self.cfg = cfg
         if template is not None and template_path is not None:
             raise ValueError("Provide either template or template_path, not both")
@@ -47,8 +65,10 @@ class Deidentifier:
                 template_path, reference_filename="deidentification_prompt.jinja2"
             )
         self.template = template or PromptTemplate.from_package("deidentification_prompt.jinja2")
-        os.makedirs(self.cfg.save_dir, exist_ok=True)
 
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
     @staticmethod
     def _chunk_by_words(text: str, max_words: int) -> List[str]:
         words = text.split()
@@ -56,34 +76,99 @@ class Deidentifier:
             return [text]
         return [" ".join(words[i : i + max_words]) for i in range(0, len(words), max_words)]
 
+    @staticmethod
+    def _coerce_mapping(value: Any) -> Optional[Dict[str, Any]]:
+        """Attempt to convert ``value`` into a mapping dictionary."""
 
+        if value is None:
+            return None
+        try:
+            if pd.isna(value):  # type: ignore[arg-type]
+                return None
+        except Exception:
+            pass
+
+        if isinstance(value, dict):
+            return deepcopy(value)
+
+        if isinstance(value, str):
+            cleaned = value.strip()
+            if not cleaned or cleaned.lower() in {"nan", "none"}:
+                return None
+            try:
+                parsed = json.loads(cleaned)
+            except Exception:
+                try:
+                    parsed = ast.literal_eval(cleaned)
+                except Exception:
+                    return None
+            if isinstance(parsed, dict):
+                return deepcopy(parsed)
+            return None
+
+        return None
+
+    # ------------------------------------------------------------------
+    # Main entry point
+    # ------------------------------------------------------------------
     async def run(
         self,
         df: pd.DataFrame,
         column_name: str,
         *,
         grouping_column: Optional[str] = None,
+        mapping_column: Optional[str] = None,
         reset_files: bool = False,
         **kwargs: Any,
     ) -> pd.DataFrame:
         """Deidentify all texts in ``df[column_name]``.
 
-        A ``grouping_column`` can be provided to ensure that the mapping is built
-        across multiple rows belonging to the same group.
+        Parameters
+        ----------
+        df:
+            Input DataFrame.
+        column_name:
+            Name of the column containing the text to de-identify.
+        grouping_column:
+            Optional column whose values determine which rows belong to the same
+            individual/entity. When omitted, each row is treated independently.
+        mapping_column:
+            Optional column containing pre-existing mapping dictionaries. The
+            first non-empty mapping encountered for each group is used as the
+            warm start and is also the mapping reused when
+            ``use_existing_mappings_only`` is ``True``.
+        reset_files:
+            When ``True``, intermediate CSV logs from :func:`get_all_responses`
+            are regenerated.
+        **kwargs:
+            Additional keyword arguments forwarded to
+            :func:`gabriel.utils.openai_utils.get_all_responses`.
         """
+
+        if column_name not in df.columns:
+            raise ValueError(f"Column '{column_name}' not found in DataFrame")
+        if grouping_column is not None and grouping_column not in df.columns:
+            raise ValueError(
+                f"Grouping column '{grouping_column}' not found in DataFrame"
+            )
+        if mapping_column is not None and mapping_column not in df.columns:
+            raise ValueError(
+                f"Mapping column '{mapping_column}' not found in DataFrame"
+            )
+
         df_proc = df.reset_index(drop=True).copy()
+
         if grouping_column is None:
             df_proc["group_id"] = df_proc.index.astype(str)
         else:
             df_proc["group_id"] = df_proc[grouping_column].astype(str)
 
         group_ids = df_proc["group_id"].unique().tolist()
-        group_segments: Dict[str, List[str]] = {}
+        base_name = Path(self.cfg.file_name).stem
+        csv_path = Path(self.cfg.save_dir) / f"{base_name}_cleaned.csv"
+        raw_prefix = Path(self.cfg.save_dir) / f"{base_name}_raw_responses"
 
-        base_name = os.path.splitext(self.cfg.file_name)[0]
-        csv_path = os.path.join(self.cfg.save_dir, f"{base_name}_cleaned.csv")
-        raw_root = os.path.join(self.cfg.save_dir, f"{base_name}_raw_responses")
-        base_root, ext = os.path.splitext(raw_root + ".csv")
+        group_segments: Dict[str, List[str]] = {}
         for gid in group_ids:
             segs: List[str] = []
             texts = (
@@ -97,47 +182,107 @@ class Deidentifier:
             group_segments[gid] = segs
 
         group_to_map: Dict[str, dict] = {gid: {} for gid in group_ids}
-        max_rounds = max(len(s) for s in group_segments.values()) if group_segments else 0
 
-        for rnd in range(max_rounds):
-            prompts: List[str] = []
-            identifiers: List[str] = []
-            active_gids: List[str] = []
-            for gid in group_ids:
-                segs = group_segments[gid]
-                if rnd < len(segs):
-                    prompts.append(
-                        self.template.render(
-                            text=segs[rnd],
-                            current_map=json.dumps(group_to_map[gid], ensure_ascii=False),
-                            guidelines=self.cfg.guidelines,
-                            additional_guidelines=self.cfg.additional_guidelines,
-                        )
-                    )
-                    identifiers.append(f"{gid}_seg_{rnd}")
-                    active_gids.append(gid)
-            if not prompts:
-                continue
-            batch_df = await get_all_responses(
-                prompts=prompts,
-                identifiers=identifiers,
-                n_parallels=self.cfg.n_parallels,
-                model=self.cfg.model,
-                save_path=f"{base_root}_round{rnd}{ext}",
-                use_dummy=self.cfg.use_dummy,
-                max_timeout=self.cfg.max_timeout,
-                json_mode=True,
-                reasoning_effort=self.cfg.reasoning_effort,
-                reasoning_summary=self.cfg.reasoning_summary,
-                reset_files=reset_files,
-                **kwargs,
+        warm_start_count = 0
+        if mapping_column is not None:
+            for gid, subset in df_proc.groupby("group_id"):
+                values = subset[mapping_column].tolist()
+                mapping = next(
+                    (m for m in (self._coerce_mapping(v) for v in values) if m is not None),
+                    None,
+                )
+                if mapping is not None:
+                    group_to_map[str(gid)] = mapping
+                    warm_start_count += 1
+            if warm_start_count:
+                print(
+                    f"[Deidentify] Loaded {warm_start_count} warm-start mapping(s) "
+                    f"from column '{mapping_column}'."
+                )
+            else:
+                print(
+                    f"[Deidentify] Column '{mapping_column}' provided but no usable "
+                    "mappings were found."
+                )
+
+        print(
+            "[Deidentify] Tip: edit the first mapping for each group and rerun with "
+            "use_existing_mappings_only=True to apply your changes without new LLM calls."
+        )
+
+        max_rounds = max(len(segs) for segs in group_segments.values()) if group_segments else 0
+
+        if self.cfg.use_existing_mappings_only:
+            print(
+                "[Deidentify] use_existing_mappings_only=True -> skipping LLM calls and "
+                "reusing provided mappings."
             )
-            for ident, resp in zip(batch_df["Identifier"], batch_df["Response"]):
-                gid = ident.split("_seg_")[0]
-                main = resp[0] if isinstance(resp, list) and resp else ""
-                parsed = await safest_json(main)
-                if parsed:
-                    group_to_map[gid] = parsed
+            missing = [gid for gid, mapping in group_to_map.items() if not mapping]
+            if missing:
+                print(
+                    "[Deidentify] Warning: no mapping provided for "
+                    f"{len(missing)} group(s). Their text will be returned unchanged."
+                )
+        else:
+            for pass_idx in range(self.cfg.n_passes):
+                if self.cfg.n_passes > 1:
+                    print(
+                        f"[Deidentify] Starting pass {pass_idx + 1}/{self.cfg.n_passes}."
+                    )
+
+                for rnd in range(max_rounds):
+                    prompts: List[str] = []
+                    identifiers: List[str] = []
+                    id_to_gid: Dict[str, str] = {}
+
+                    for gid in group_ids:
+                        segs = group_segments[gid]
+                        if rnd >= len(segs):
+                            continue
+
+                        ident = f"{gid}_pass{pass_idx}_seg_{rnd}"
+                        identifiers.append(ident)
+                        id_to_gid[ident] = gid
+                        prompts.append(
+                            self.template.render(
+                                text=segs[rnd],
+                                current_map=json.dumps(
+                                    group_to_map.get(gid, {}), ensure_ascii=False
+                                ),
+                                guidelines=self.cfg.guidelines,
+                                additional_guidelines=self.cfg.additional_guidelines,
+                            )
+                        )
+
+                    if not prompts:
+                        continue
+
+                    save_path = raw_prefix.with_name(
+                        f"{raw_prefix.name}_pass{pass_idx}_round{rnd}.csv"
+                    )
+                    batch_df = await get_all_responses(
+                        prompts=prompts,
+                        identifiers=identifiers,
+                        n_parallels=self.cfg.n_parallels,
+                        model=self.cfg.model,
+                        save_path=str(save_path),
+                        use_dummy=self.cfg.use_dummy,
+                        max_timeout=self.cfg.max_timeout,
+                        json_mode=True,
+                        reasoning_effort=self.cfg.reasoning_effort,
+                        reasoning_summary=self.cfg.reasoning_summary,
+                        reset_files=reset_files,
+                        **kwargs,
+                    )
+
+                    for ident, resp in zip(batch_df["Identifier"], batch_df["Response"]):
+                        gid = id_to_gid.get(ident)
+                        if gid is None:
+                            continue
+                        main = resp[0] if isinstance(resp, list) and resp else ""
+                        parsed = await safest_json(main)
+                        if isinstance(parsed, dict):
+                            group_to_map[gid] = parsed
 
         mappings_col: List[dict] = []
         deidentified_texts: List[str] = []
@@ -151,8 +296,9 @@ class Deidentifier:
             for entry in mapping.values():
                 if isinstance(entry, dict):
                     casted = entry.get("casted form", "")
-                    for real in entry.get("real forms", []):
-                        pairs.append((real, casted))
+                    for real in entry.get("real forms", []) or []:
+                        if casted and real:
+                            pairs.append((real, casted))
             pairs.sort(key=lambda x: len(x[0]), reverse=True)
             for real, casted in pairs:
                 pattern = re.compile(rf"\b{re.escape(real)}\b", flags=re.IGNORECASE)


### PR DESCRIPTION
## Summary
- align the deidentify task configuration with other task patterns and expand runtime validation
- add warm-start mapping ingestion, optional multi-pass runs, and a flag to reuse mappings without new LLM calls
- surface the new capabilities through the API wrapper and improve user guidance prints

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_i_68cc4805fe8c832ea127ee64ce916e1b