### PR TITLE
Consolidate web search flag usage across helpers

### DIFF
--- a/src/gabriel/tasks/classify.py
+++ b/src/gabriel/tasks/classify.py
@@ -331,7 +331,7 @@ class Classify:
             except Exception:
                 pass
 
-        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("web_search", self.cfg.modality == "web")
 
         if not isinstance(self.cfg.n_runs, int) or self.cfg.n_runs < 1:
             raise ValueError("n_runs must be an integer >= 1")

--- a/src/gabriel/tasks/compare.py
+++ b/src/gabriel/tasks/compare.py
@@ -159,7 +159,7 @@ class Compare:
 
         csv_path = os.path.join(self.cfg.save_dir, self.cfg.file_name)
 
-        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("web_search", self.cfg.modality == "web")
 
         df_resp_all = await get_all_responses(
             prompts=prompts,

--- a/src/gabriel/tasks/extract.py
+++ b/src/gabriel/tasks/extract.py
@@ -136,7 +136,7 @@ class Extract:
         base_name = os.path.splitext(self.cfg.file_name)[0]
         csv_path = os.path.join(self.cfg.save_dir, f"{base_name}_raw_responses.csv")
 
-        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("web_search", self.cfg.modality == "web")
 
         if not isinstance(self.cfg.n_runs, int) or self.cfg.n_runs < 1:
             raise ValueError("n_runs must be an integer >= 1")

--- a/src/gabriel/tasks/paraphrase.py
+++ b/src/gabriel/tasks/paraphrase.py
@@ -43,8 +43,10 @@ class ParaphraseConfig:
     model: str = "gpt-5-mini"
     # When true, the model will be asked to output JSON only.
     json_mode: bool = False
-    # If true, the underlying helper will use web search augmentation.
-    use_web_search: bool = False
+    # When set, controls whether the underlying helper should use web search
+    # augmentation.  ``None`` defers to downstream defaults while ``True`` and
+    # ``False`` explicitly enable or disable the feature.
+    web_search: Optional[bool] = None
     # Maximum number of parallel requests that will be sent to the
     # underlying API.  Note that classification and paraphrasing share
     # this value for simplicity.
@@ -158,7 +160,7 @@ class Paraphrase:
                 save_path=save_path,
                 model=self.cfg.model,
                 json_mode=self.cfg.json_mode,
-                use_web_search=self.cfg.use_web_search,
+                web_search=self.cfg.web_search,
                 n_parallels=self.cfg.n_parallels,
                 use_dummy=self.cfg.use_dummy,
                 reset_files=reset_files,
@@ -329,7 +331,7 @@ class Paraphrase:
                 save_path=tmp_save_path,
                 model=self.cfg.model,
                 json_mode=self.cfg.json_mode,
-                use_web_search=self.cfg.use_web_search,
+                web_search=self.cfg.web_search,
                 n_parallels=self.cfg.n_parallels,
                 use_dummy=self.cfg.use_dummy,
                 reset_files=reset_files,

--- a/src/gabriel/tasks/rank.py
+++ b/src/gabriel/tasks/rank.py
@@ -331,7 +331,7 @@ class Rank:
         combined_kwargs = dict(run_kwargs)
         if runtime_kwargs:
             combined_kwargs.update(runtime_kwargs)
-        combined_kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        combined_kwargs.setdefault("web_search", self.cfg.modality == "web")
         rate_task = Rate(rate_cfg)
         return await rate_task.run(
             df,
@@ -1311,7 +1311,7 @@ class Rank:
             each attribute's score, optional z‑score and standard
             error.  The DataFrame is also written to ``save_dir``.
         """
-        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("web_search", self.cfg.modality == "web")
         if self.cfg.recursive:
             return await self._run_recursive(
                 df,

--- a/src/gabriel/tasks/rate.py
+++ b/src/gabriel/tasks/rate.py
@@ -187,7 +187,7 @@ class Rate:
             except Exception:
                 pass
 
-        kwargs.setdefault("use_web_search", self.cfg.modality == "web")
+        kwargs.setdefault("web_search", self.cfg.modality == "web")
 
         if not isinstance(self.cfg.n_runs, int) or self.cfg.n_runs < 1:
             raise ValueError("n_runs must be an integer >= 1")

--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -1573,7 +1573,6 @@ async def get_all_responses(
     tools: Optional[List[dict]] = None,
     tool_choice: Optional[dict] = None,
     web_search: Optional[bool] = None,
-    use_web_search: Optional[bool] = None,
     web_search_filters: Optional[Dict[str, Any]] = None,
     search_context_size: str = "medium",
     reasoning_effort: Optional[str] = None,
@@ -1721,9 +1720,10 @@ async def get_all_responses(
     # ``use_web_search`` was the original parameter name; ``web_search`` is the
     # preferred modern spelling.  If both are supplied we favour ``web_search``
     # but emit a warning for awareness.
-    if web_search is None:
-        web_search = bool(use_web_search)
-    elif use_web_search is not None and use_web_search != web_search:
+    legacy_use_web_search = get_response_kwargs.pop("use_web_search", None)
+    if web_search is None and legacy_use_web_search is not None:
+        web_search = bool(legacy_use_web_search)
+    elif legacy_use_web_search is not None and bool(legacy_use_web_search) != web_search:
         logger.warning(
             "`use_web_search` is deprecated; please use `web_search` instead."
         )


### PR DESCRIPTION
## Summary
- standardize the high-level paraphrase and whatever wrappers to expose a single `web_search` flag while gracefully accepting legacy `use_web_search`
- propagate the unified flag through task helpers so modality-driven defaults now set `web_search`
- teach `get_all_responses` to coerce any lingering `use_web_search` keyword into the modern `web_search` option before forwarding to the response helper

## Testing
- pytest tests/test_basic.py::test_get_all_responses_dummy

------
https://chatgpt.com/codex/tasks/task_i_68dbfc820d8c832eaeab7e3b56d96139