### PR TITLE
Add per-prompt web search filters and flexible whatever runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,21 @@ print(responses[0])
 ```
 
 Images are provided as base64 strings, while audio items are dictionaries with `data` and `format`. Helper functions `encode_image` and `encode_audio` are available for local files.
+
+### Per-prompt web search filters
+
+`get_all_responses` accepts a `prompt_web_search_filters` mapping for prompt-specific web search hints. The keys should match the prompt identifiers passed to `get_all_responses` and each value should mirror the structure of `web_search_filters` (for example including `city`, `region`, `country`, `timezone`, `type`, or `allowed_domains`). These per-prompt settings are merged with any global `web_search_filters` before each request, so you can keep a shared domain whitelist while pulling location hints from a DataFrame column on a row-by-row basis. See `gabriel.utils.openai_utils` for the full normalisation logic.
+
+### Custom prompts with `gabriel.whatever`
+
+Use `gabriel.whatever` when you need a thin wrapper around `get_all_responses`. The helper can work with a single string prompt, a list of prompts, or a DataFrame column. When a DataFrame is supplied you can optionally specify:
+
+- `column_name` – which column contains the prompt text (required for DataFrame input).
+- `identifier_column` – supply unique IDs; otherwise short SHA1 identifiers are generated.
+- `image_column` / `audio_column` – columns containing media to be encoded automatically via `load_image_inputs` and `load_audio_inputs`.
+- `web_search_filters` – pass a dictionary whose values may be column names; for example `{"city": "city_col", "allowed_domains": "domains"}` will read the appropriate cell for every prompt and build a `prompt_web_search_filters` map automatically.
+
+Results are saved to `save_dir/file_name` and all other keyword arguments are forwarded to `get_all_responses`, making it easy to reuse advanced features like JSON mode, batches, or custom tool definitions.
 ### Custom prompt templates
 
 All task classes and the high-level API functions accept a `template_path`

--- a/src/gabriel/tasks/__init__.py
+++ b/src/gabriel/tasks/__init__.py
@@ -34,6 +34,8 @@ _lazy_imports = {
     "DiscoverConfig": ".discover",
     "Filter": ".filter",
     "FilterConfig": ".filter",
+    "Whatever": ".whatever",
+    "WhateverConfig": ".whatever",
     "DebiasPipeline": ".debias",
     "DebiasConfig": ".debias",
     "DebiasResult": ".debias",

--- a/src/gabriel/tasks/whatever.py
+++ b/src/gabriel/tasks/whatever.py
@@ -1,0 +1,254 @@
+"""Lightweight runner for arbitrary prompts via :func:`get_all_responses`."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Union
+
+import pandas as pd
+
+from ..utils import load_audio_inputs, load_image_inputs
+from ..utils.openai_utils import get_all_responses
+
+
+@dataclass
+class WhateverConfig:
+    """Configuration for :class:`Whatever`."""
+
+    save_dir: str = "whatever"
+    file_name: str = "custom_prompt_responses.csv"
+    model: str = "gpt-5-mini"
+    json_mode: bool = False
+    web_search: Optional[bool] = None
+    web_search_filters: Optional[Dict[str, Any]] = None
+    search_context_size: str = "medium"
+    n_parallels: int = 750
+    use_dummy: bool = False
+    reasoning_effort: Optional[str] = None
+    reasoning_summary: Optional[str] = None
+
+
+class Whatever:
+    """Prepare prompts and dispatch them through :func:`get_all_responses`."""
+
+    def __init__(self, cfg: WhateverConfig) -> None:
+        expanded = os.path.expandvars(os.path.expanduser(cfg.save_dir))
+        os.makedirs(expanded, exist_ok=True)
+        cfg.save_dir = expanded
+        self.cfg = cfg
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _generate_identifiers(
+        prompts: List[str], provided: Optional[List[str]] = None
+    ) -> List[str]:
+        if provided is not None:
+            if len(provided) != len(prompts):
+                raise ValueError("Length of identifiers must match number of prompts")
+            ids = [str(i) for i in provided]
+            if len(set(ids)) != len(ids):
+                raise ValueError("Identifiers must be unique")
+            return ids
+
+        counts: Dict[str, int] = {}
+        generated: List[str] = []
+        for prompt in prompts:
+            key = hashlib.sha1(prompt.encode("utf-8")).hexdigest()[:8]
+            idx = counts.get(key, 0)
+            counts[key] = idx + 1
+            ident = key if idx == 0 else f"{key}-{idx}"
+            generated.append(ident)
+        return generated
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _is_missing(value: Any) -> bool:
+        if value is None:
+            return True
+        try:
+            res = pd.isna(value)
+        except Exception:
+            return False
+        try:
+            return bool(res)
+        except Exception:
+            return False
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _coerce_domains(value: Any) -> List[str]:
+        if Whatever._is_missing(value):
+            return []
+        if isinstance(value, str):
+            return [part.strip() for part in value.split(",") if part.strip()]
+        if isinstance(value, dict):
+            return []
+        if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+            domains = [str(item).strip() for item in value if str(item).strip()]
+            return domains
+        text = str(value).strip()
+        return [text] if text else []
+
+    # ------------------------------------------------------------------
+    async def run(
+        self,
+        data: Union[str, List[str], pd.DataFrame],
+        *,
+        identifiers: Optional[List[str]] = None,
+        column_name: Optional[str] = None,
+        identifier_column: Optional[str] = None,
+        image_column: Optional[str] = None,
+        audio_column: Optional[str] = None,
+        prompt_images: Optional[Dict[str, List[str]]] = None,
+        prompt_audio: Optional[Dict[str, List[Dict[str, str]]]] = None,
+        web_search_filters: Optional[Dict[str, Any]] = None,
+        reset_files: bool = False,
+        **kwargs: Any,
+    ) -> pd.DataFrame:
+        """Normalise inputs and call :func:`get_all_responses`."""
+
+        filters_spec: Dict[str, Any] = dict(
+            web_search_filters
+            if web_search_filters is not None
+            else (self.cfg.web_search_filters or {})
+        )
+
+        df_filters: Optional[Dict[str, Dict[str, Any]]] = None
+        global_filters: Optional[Dict[str, Any]] = filters_spec or None
+
+        if isinstance(data, pd.DataFrame):
+            if column_name is None:
+                raise ValueError("column_name must be provided when passing a DataFrame")
+            if column_name not in data.columns:
+                raise ValueError(f"Column '{column_name}' not found in DataFrame")
+            df = data.reset_index(drop=True)
+            prompt_series = df[column_name]
+            prompt_values = [
+                "" if self._is_missing(val) else str(val)
+                for val in prompt_series.tolist()
+            ]
+            if identifier_column is not None:
+                if identifier_column not in df.columns:
+                    raise ValueError(
+                        f"Identifier column '{identifier_column}' not found in DataFrame"
+                    )
+                identifiers_list = [str(i) for i in df[identifier_column].tolist()]
+                if len(set(identifiers_list)) != len(identifiers_list):
+                    raise ValueError("identifier_column must contain unique values")
+            else:
+                identifiers_list = self._generate_identifiers(prompt_values)
+
+            image_map: Dict[str, List[str]] = {}
+            if image_column is not None:
+                if image_column not in df.columns:
+                    raise ValueError(
+                        f"Image column '{image_column}' not found in DataFrame"
+                    )
+                for ident, cell in zip(identifiers_list, df[image_column]):
+                    imgs = load_image_inputs(cell)
+                    if imgs:
+                        image_map[str(ident)] = imgs
+
+            audio_map: Dict[str, List[Dict[str, str]]] = {}
+            if audio_column is not None:
+                if audio_column not in df.columns:
+                    raise ValueError(
+                        f"Audio column '{audio_column}' not found in DataFrame"
+                    )
+                for ident, cell in zip(identifiers_list, df[audio_column]):
+                    auds = load_audio_inputs(cell)
+                    if auds:
+                        audio_map[str(ident)] = auds
+
+            column_filters: Dict[str, str] = {}
+            base_filters: Dict[str, Any] = {}
+            for key, spec in filters_spec.items():
+                if isinstance(spec, str) and spec in df.columns:
+                    column_filters[key] = spec
+                elif key == "allowed_domains" and isinstance(spec, str) and spec in df.columns:
+                    column_filters[key] = spec
+                else:
+                    base_filters[key] = spec
+
+            per_prompt_filters: Dict[str, Dict[str, Any]] = {}
+            if column_filters:
+                for idx, ident in enumerate(identifiers_list):
+                    row = df.iloc[idx]
+                    row_filters: Dict[str, Any] = {}
+                    for key, col in column_filters.items():
+                        value = row.get(col)
+                        if self._is_missing(value):
+                            continue
+                        if key == "allowed_domains":
+                            domains = self._coerce_domains(value)
+                            if domains:
+                                row_filters[key] = domains
+                        else:
+                            text = str(value).strip()
+                            if text:
+                                row_filters[key] = text
+                    if row_filters:
+                        per_prompt_filters[str(ident)] = row_filters
+            df_filters = per_prompt_filters or None
+            global_filters = base_filters or None
+
+            prompts_list = prompt_values
+        else:
+            if isinstance(data, str):
+                prompts_list = [data]
+            else:
+                prompts_list = [str(p) for p in data]
+            identifiers_list = self._generate_identifiers(
+                prompts_list, identifiers
+            )
+            image_map = {}
+            audio_map = {}
+
+        if prompt_images:
+            if not isinstance(prompt_images, dict):
+                raise TypeError("prompt_images must be a mapping of identifier to images")
+            for key, val in prompt_images.items():
+                if val:
+                    image_map[str(key)] = val
+
+        if prompt_audio:
+            if not isinstance(prompt_audio, dict):
+                raise TypeError("prompt_audio must be a mapping of identifier to audio payloads")
+            for key, val in prompt_audio.items():
+                if val:
+                    audio_map[str(key)] = val
+
+        images_payload = image_map or None
+        audio_payload = audio_map or None
+
+        save_path = kwargs.pop(
+            "save_path", os.path.join(self.cfg.save_dir, self.cfg.file_name)
+        )
+
+        web_search_flag = (
+            self.cfg.web_search
+            if self.cfg.web_search is not None
+            else bool(global_filters or df_filters)
+        )
+
+        return await get_all_responses(
+            prompts=prompts_list,
+            identifiers=identifiers_list,
+            prompt_images=images_payload,
+            prompt_audio=audio_payload,
+            prompt_web_search_filters=df_filters,
+            save_path=save_path,
+            model=self.cfg.model,
+            json_mode=self.cfg.json_mode,
+            web_search=web_search_flag,
+            web_search_filters=global_filters,
+            search_context_size=self.cfg.search_context_size,
+            n_parallels=self.cfg.n_parallels,
+            use_dummy=self.cfg.use_dummy,
+            reset_files=reset_files,
+            reasoning_effort=self.cfg.reasoning_effort,
+            reasoning_summary=self.cfg.reasoning_summary,
+            **kwargs,
+        )


### PR DESCRIPTION
## Summary
- allow `get_all_responses` to merge per-identifier web search filters with global settings
- add a configurable `Whatever` task and update the API wrapper to accept strings, lists, or DataFrames with media and web search columns
- document the new workflow and cover it with unit tests

## Testing
- pytest tests/test_basic.py -q

------
https://chatgpt.com/codex/tasks/task_i_68dc3b2d4534832e8c58e923825bc4e1