### PR TITLE
Refresh README with modern usage guidance

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
-# GABRIEL Documentation
+# GABRIEL documentation
 
-Documentation coming soon.
+The primary usage guide now lives in the top-level [README](../README.md), which covers installation, quick-start examples, and detailed explanations of every high-level helper (e.g. `gabriel.rate`, `gabriel.rank`, `gabriel.classify`).
+
+Additional deep dives, prompt templates, and walkthroughs are being migrated from research notebooks.  Until the full docs site is published, start with the tutorial Colab linked in the README and explore the `notebooks/` folder for worked examples.


### PR DESCRIPTION
## Summary
- overhaul the top-level README with an updated introduction, installation steps, quick-start example, and comprehensive task descriptions
- document media attachments, web search support, best practices, and output handling for the asynchronous helpers
- point the docs README to the main guide while noting the forthcoming deep dives

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_i_68dd685f1120832e9cd5e9958155fda6