### PR TITLE
Improve response polling resiliency

### DIFF
--- a/tests/test_input_image_url.py
+++ b/tests/test_input_image_url.py
@@ -28,7 +28,7 @@ def test_get_response_encodes_image(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     openai_utils.client_async = None
     dummy = DummyClient()
-    monkeypatch.setattr(openai, "AsyncOpenAI", lambda: dummy)
+    monkeypatch.setattr(openai, "AsyncOpenAI", lambda **_: dummy)
     asyncio.run(openai_utils.get_response("Describe", images=["abc"], use_dummy=False))
     assert (
         DummyClient.captured["input"][0]["content"][1]["image_url"]


### PR DESCRIPTION
## Summary
- add optional background polling to `get_response` and enable it automatically while dynamic timeouts are unbounded so long-running jobs cannot stall
- record completed response IDs in `get_all_responses` output rows and surface background configuration parameters
- extend the test suite with coverage for the background polling path and update image-encoding test stubs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_i_68e01cf8a978832e908d64066d19acea