### PR TITLE
Handle missing response IDs on timeouts

### DIFF
--- a/src/gabriel/utils/openai_utils.py
+++ b/src/gabriel/utils/openai_utils.py
@@ -3032,6 +3032,7 @@ async def get_all_responses(
                     task,
                     call_timeout if call_timeout is not None else float("inf"),
                 )
+                response_ids: List[str] = []
                 try:
                     result = await task
                 except asyncio.CancelledError:
@@ -3056,7 +3057,6 @@ async def get_all_responses(
                 limiter_wait_durations.append(limiter_wait_time)
                 limiter_wait_ratios.append(limiter_wait_ratio)
                 total_input, total_output, total_reasoning = _aggregate_usage(raw)
-                response_ids = []
                 for item in _coerce_to_list(raw):
                     rid = _safe_get(item, "id")
                     if rid:


### PR DESCRIPTION
## Summary
- initialize the `response_ids` collection before awaiting the OpenAI call in `get_all_responses`
- prevent timeout and cancellation paths from referencing an undefined variable when a request fails early

## Testing
- `pytest tests/test_basic.py::test_get_all_responses_dummy`


------
https://chatgpt.com/codex/tasks/task_i_68e025b5a1bc832ebb5fd08286c06f81