### PR TITLE
Add web search safeguards for get_all_responses

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -331,6 +331,22 @@ def test_usage_overview_reports_remaining_budget_reason(capsys):
     assert "Upgrading your tier" not in captured
 
 
+def test_web_search_warning_and_parallel_cap(tmp_path, capsys):
+    asyncio.run(
+        openai_utils.get_all_responses(
+            prompts=["search"],
+            identifiers=["1"],
+            save_path=str(tmp_path / "web.csv"),
+            use_dummy=True,
+            web_search=True,
+            n_parallels=12,
+        )
+    )
+    captured = capsys.readouterr().out
+    assert "Web search is enabled" in captured
+    assert "automatically capped parallel workers" in captured
+
+
 def test_get_all_responses_custom_usage(tmp_path):
     recorded_kwargs = []
 


### PR DESCRIPTION
## Summary
- add explicit warning and documentation about the extra cost of enabling web search in get_all_responses
- automatically reduce the worker ceiling when web search is enabled and surface the note in the usage overview
- cover the new behaviour with a regression test

## Testing
- pytest tests/test_basic.py::test_web_search_warning_and_parallel_cap

------
https://chatgpt.com/codex/tasks/task_i_68e02d582940832eb2634db8999d7a0d