### PR TITLE
Fix dynamic timeout watcher to cancel long-running tasks

### DIFF
--- a/tests/test_timeout_logic.py
+++ b/tests/test_timeout_logic.py
@@ -1,8 +1,12 @@
 """Tests for timeout selection helpers."""
 
 import math
+import time
 
-from gabriel.utils.openai_utils import _resolve_effective_timeout
+from gabriel.utils.openai_utils import (
+    _resolve_effective_timeout,
+    _should_cancel_inflight_task,
+)
 
 
 def test_resolve_effective_timeout_uses_task_budget_when_available() -> None:
@@ -21,3 +25,19 @@ def test_resolve_effective_timeout_respects_explicit_timeouts_when_static() -> N
     """Static timeout configuration should always use the provided value."""
 
     assert _resolve_effective_timeout(math.inf, 40.0, False) == 40.0
+
+
+def test_should_cancel_inflight_honors_dynamic_budget() -> None:
+    """Tasks dispatched before initialization adopt the global timeout."""
+
+    start = time.time() - 100.0
+    now = time.time()
+    assert _should_cancel_inflight_task(start, now, 90.0, math.inf, True)
+
+
+def test_should_cancel_inflight_skips_infinite_budgets() -> None:
+    """When no timeout applies the watcher should not cancel tasks."""
+
+    start = time.time() - 10.0
+    now = time.time()
+    assert not _should_cancel_inflight_task(start, now, math.inf, math.inf, True)


### PR DESCRIPTION
## Summary
- ensure the timeout watcher respects dynamically adjusted limits for in-flight requests
- factor timeout cancellation checks into a helper and cover it with unit tests

## Testing
- pytest tests/test_timeout_logic.py

------
https://chatgpt.com/codex/tasks/task_i_68e04e0ef46c832ea6741cb1a72364b3